### PR TITLE
[Feature] Implicit/Hybridフローに対応する

### DIFF
--- a/YJLoginSDK.xcodeproj/project.pbxproj
+++ b/YJLoginSDK.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		83B51BA32ACD50EA001FD932 /* YJLoginSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B1DCE1DA22B263F2005F5703 /* YJLoginSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		83B51BA62ACD50F5001FD932 /* YJLoginSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DCE1DA22B263F2005F5703 /* YJLoginSDK.framework */; };
 		83B51BA72ACD50F5001FD932 /* YJLoginSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B1DCE1DA22B263F2005F5703 /* YJLoginSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9D6510852C6D5D82008FEF62 /* Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6510842C6D5D82008FEF62 /* Flow.swift */; };
 		B10562CC2398A62D00359322 /* Data+base64url.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10562CB2398A62D00359322 /* Data+base64url.swift */; };
 		B10562CE2398C00000359322 /* SecureRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10562CD2398C00000359322 /* SecureRandom.swift */; };
 		B10A5EB8230BECA600EBB294 /* LoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8D75E22C5B713004CF30C /* LoginButton.swift */; };
@@ -99,6 +100,7 @@
 
 /* Begin PBXFileReference section */
 		636D634D2B85F855005C348D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		9D6510842C6D5D82008FEF62 /* Flow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flow.swift; sourceTree = "<group>"; };
 		B10562CB2398A62D00359322 /* Data+base64url.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+base64url.swift"; sourceTree = "<group>"; };
 		B10562CD2398C00000359322 /* SecureRandom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureRandom.swift; sourceTree = "<group>"; };
 		B10FD9F022FC33820048A4B7 /* LoginButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButtonTests.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 				B1DCE1F922B265C8005F5703 /* LoginManager.swift */,
 				B1C8D75E22C5B713004CF30C /* LoginButton.swift */,
 				B1B7D38F22FA952600D35A8B /* LoginResult.swift */,
+				9D6510842C6D5D82008FEF62 /* Flow.swift */,
 				B1EEBF2E22FD4BC1009F600D /* Constant.swift */,
 				B1DCE1DD22B263F2005F5703 /* YJLoginSDK.h */,
 				B1D5762522DC4EA500A85071 /* Assets.xcassets */,
@@ -467,6 +470,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D6510852C6D5D82008FEF62 /* Flow.swift in Sources */,
 				B10A5EB8230BECA600EBB294 /* LoginButton.swift in Sources */,
 				B1D5762422D884E100A85071 /* OptionalParameters.swift in Sources */,
 				B10562CC2398A62D00359322 /* Data+base64url.swift in Sources */,

--- a/YJLoginSDK/Flow.swift
+++ b/YJLoginSDK/Flow.swift
@@ -1,0 +1,46 @@
+//
+//  Flow.swift
+//  YJLoginSDK
+//
+//  © 2024 Yahoo Japan Corporation. All rights reserved.
+//
+
+import Foundation
+
+/// コード認証フロー。
+enum Flow {
+    /// Authentication Codeフロー
+    case authenticationCode
+    
+    /// Implicitフロー。
+    case implicit
+    
+    /// Hybridフロー
+    case hybrid
+    
+    /// `ResponseType`の配列からコード認証フローを取得する
+    /// - Parameter responseTypes: `ResponseType`の配列
+    init(responseTypes: [ResponseType]) {
+        var containsCode = false
+        var containsToken = false
+        for responseType in responseTypes {
+            switch responseType {
+            case .code:
+                containsCode = true
+            case .idToken, .token:
+                containsToken = true
+            }
+        }
+        
+        switch (containsCode, containsToken) {
+        case (true, true):
+            self = .hybrid
+        case (true, false):
+            self = .authenticationCode
+        case (false, false):
+            self = .implicit
+        default:
+            fatalError("responseTypes must not be empty.")
+        }
+    }
+}

--- a/YJLoginSDK/Flow.swift
+++ b/YJLoginSDK/Flow.swift
@@ -20,7 +20,7 @@ public enum Flow {
     
     /// `ResponseType`の配列からコード認証フローを取得する
     /// - Parameter responseTypes: `ResponseType`の配列
-    init(responseTypes: [ResponseType]) {
+    init(responseTypes: [ResponseType]) {        
         var containsCode = false
         var containsToken = false
         for responseType in responseTypes {
@@ -37,10 +37,10 @@ public enum Flow {
             self = .hybrid
         case (true, false):
             self = .authenticationCode
-        case (false, false):
+        case (false, true):
             self = .implicit
         default:
-            fatalError("responseTypes must not be empty.")
+            fatalError("[YJLoginSDK] Invalid case.")
         }
     }
 }

--- a/YJLoginSDK/Flow.swift
+++ b/YJLoginSDK/Flow.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 /// コード認証フロー。
-enum Flow {
+public enum Flow {
     /// Authentication Codeフロー
     case authenticationCode
     
     /// Implicitフロー。
     case implicit
     
-    /// Hybridフロー
+    /// Hybridフロー。
     case hybrid
     
     /// `ResponseType`の配列からコード認証フローを取得する

--- a/YJLoginSDK/LoginButton.swift
+++ b/YJLoginSDK/LoginButton.swift
@@ -72,6 +72,12 @@ public class LoginButton: UIButton {
 
     /// 認可リクエストで指定するcodeChallenge。
     public var codeChallenge: String!
+    
+    /// 認可リクエストで指定するstate
+    public var expectedState: String!
+    
+    /// 認可リクエストで指定するresponseTypes
+    public var responseTypes: [ResponseType] = [.code]
 
     /// 認可リクエストで指定するその他の任意パラメーター。
     public var optionalParameters: OptionalParameters?
@@ -114,7 +120,7 @@ public class LoginButton: UIButton {
         isUserInteractionEnabled = false
         delegate?.loginButtonDidStartLogin(self)
         let process = self.process ?? AuthenticationProcess(viewController: presentingViewController, responseTypes: [.code])
-        LoginManager.shared.login(scopes: scopes, nonce: nonce, codeChallenge: codeChallenge, process: process, optionalParameters: optionalParameters) {[weak self] result in
+        LoginManager.shared.login(scopes: scopes, nonce: nonce, codeChallenge: codeChallenge, state: expectedState, responseTypes: responseTypes, process: process, optionalParameters: optionalParameters) {[weak self] result in
             if let self {
                 switch result {
                 case .success(let response):

--- a/YJLoginSDK/LoginButton.swift
+++ b/YJLoginSDK/LoginButton.swift
@@ -113,7 +113,7 @@ public class LoginButton: UIButton {
     @objc private func login() {
         isUserInteractionEnabled = false
         delegate?.loginButtonDidStartLogin(self)
-        let process = self.process ?? AuthenticationProcess(viewController: presentingViewController)
+        let process = self.process ?? AuthenticationProcess(viewController: presentingViewController, responseTypes: [.code])
         LoginManager.shared.login(scopes: scopes, nonce: nonce, codeChallenge: codeChallenge, process: process, optionalParameters: optionalParameters) {[weak self] result in
             if let self {
                 switch result {

--- a/YJLoginSDK/LoginManager.swift
+++ b/YJLoginSDK/LoginManager.swift
@@ -102,6 +102,10 @@ public class LoginManager {
         process: AuthenticationProcessProtocol,
         optionalParameters: OptionalParameters? = nil,
         completionHandler completion: @escaping (Result<LoginResult, LoginError>) -> Void) {
+            
+        guard !responseTypes.isEmpty else {
+            fatalError("[YJLoginSDK] responseTypes must not be empty.")
+        }
 
         guard let configuration else {
             fatalError("[YJLoginSDK] Please call setup function before login.")

--- a/YJLoginSDK/LoginManager.swift
+++ b/YJLoginSDK/LoginManager.swift
@@ -59,6 +59,7 @@ public class LoginManager {
     /// - Parameter nonce: リプレイアタック対策のパラメーター。
     /// - Parameter codeChallenge: PKCEのパラメーター。
     /// - Parameter state: CSRF対策のパラメーター。
+    /// - Parameter responseTypes: レスポンスタイプ。デフォルトは`[.code]`。
     /// - Parameter optionalParameters: 認可リクエスト時に指定する任意パラメーター。
     /// - Parameter viewController: ログイン画面を表示するViewController。nilの場合は最前面のViewControllerにログイン画面を表示する。
     /// - Parameter completion: ログインアクション完了時に実行されるクロージャー。
@@ -75,7 +76,7 @@ public class LoginManager {
         optionalParameters: OptionalParameters? = nil,
         viewController: UIViewController? = nil,
         completionHandler completion: @escaping (Result<LoginResult, LoginError>) -> Void) {
-        login(scopes: scopes, nonce: nonce, codeChallenge: codeChallenge, process: AuthenticationProcess(viewController: viewController), optionalParameters: optionalParameters, completionHandler: completion)
+            login(scopes: scopes, nonce: nonce, codeChallenge: codeChallenge, process: AuthenticationProcess(viewController: viewController, responseTypes: responseTypes), optionalParameters: optionalParameters, completionHandler: completion)
     }
 
     /// AppDelegateからアプリにログイン処理が返ってきた際に、URLの処理を制御する。

--- a/YJLoginSDK/LoginManager.swift
+++ b/YJLoginSDK/LoginManager.swift
@@ -58,7 +58,7 @@ public class LoginManager {
     /// - Parameter scopes: 要求する`Scope`の配列。`.openid`は必須。
     /// - Parameter nonce: リプレイアタック対策のパラメーター。
     /// - Parameter codeChallenge: PKCEのパラメーター。
-    /// - Parameter state: CSRF対策のパラメーター。
+    /// - Parameter state: CSRF対策のパラメーター。デフォルトはランダムの文字列。
     /// - Parameter responseTypes: レスポンスタイプ。デフォルトは`[.code]`。
     /// - Parameter optionalParameters: 認可リクエスト時に指定する任意パラメーター。
     /// - Parameter viewController: ログイン画面を表示するViewController。nilの場合は最前面のViewControllerにログイン画面を表示する。

--- a/YJLoginSDK/LoginManager.swift
+++ b/YJLoginSDK/LoginManager.swift
@@ -58,6 +58,7 @@ public class LoginManager {
     /// - Parameter scopes: 要求する`Scope`の配列。`.openid`は必須。
     /// - Parameter nonce: リプレイアタック対策のパラメーター。
     /// - Parameter codeChallenge: PKCEのパラメーター。
+    /// - Parameter state: CSRF対策のパラメーター。
     /// - Parameter optionalParameters: 認可リクエスト時に指定する任意パラメーター。
     /// - Parameter viewController: ログイン画面を表示するViewController。nilの場合は最前面のViewControllerにログイン画面を表示する。
     /// - Parameter completion: ログインアクション完了時に実行されるクロージャー。
@@ -68,7 +69,9 @@ public class LoginManager {
     public func login(
         scopes: [Scope],
         nonce: String,
-        codeChallenge: String,
+        codeChallenge: String? = nil,
+        state: String? = nil,
+        responseTypes: [ResponseType] = [.code],
         optionalParameters: OptionalParameters? = nil,
         viewController: UIViewController? = nil,
         completionHandler completion: @escaping (Result<LoginResult, LoginError>) -> Void) {
@@ -92,7 +95,9 @@ public class LoginManager {
     internal func login(
         scopes: [Scope],
         nonce: String,
-        codeChallenge: String,
+        codeChallenge: String?,
+        state: String? = nil,
+        responseTypes: [ResponseType] = [.code],
         process: AuthenticationProcessProtocol,
         optionalParameters: OptionalParameters? = nil,
         completionHandler completion: @escaping (Result<LoginResult, LoginError>) -> Void) {
@@ -108,9 +113,9 @@ public class LoginManager {
             return
         }
 
-        let state =  try? SecureRandom.data(count: 32).base64urlEncodedString()
+        let state = state == nil ? try? SecureRandom.data(count: 32).base64urlEncodedString() : state
 
-        let request = AuthenticationRequest(clientId: configuration.clientId, codeChallenge: codeChallenge, nonce: nonce, redirectUri: configuration.redirectUri, responseType: .code, scopes: scopes, state: state, optionalParameter: optionalParameters, issuer: configuration.issuer)
+        let request = AuthenticationRequest(clientId: configuration.clientId, codeChallenge: codeChallenge, nonce: nonce, redirectUri: configuration.redirectUri, responseTypes: responseTypes, scopes: scopes, state: state, optionalParameter: optionalParameters, issuer: configuration.issuer)
 
         authenticationProcess = process
         authenticationProcess?.setEnableUniversalLinks(enableUniversalLinks: enableUniversalLinks)

--- a/YJLoginSDK/LoginResult.swift
+++ b/YJLoginSDK/LoginResult.swift
@@ -23,7 +23,7 @@ public struct AuthorizationCodeFlowLoginResult: LoginResult {
 }
 
 /// 認可リクエストが成功した結果。(HybridFlow)
-public struct HyblidFlowLoginResult: LoginResult {
+public struct HybridFlowLoginResult: LoginResult {
     public var flow: Flow { return .hybrid }
 
     /// 認可コード。

--- a/YJLoginSDK/LoginResult.swift
+++ b/YJLoginSDK/LoginResult.swift
@@ -5,11 +5,50 @@
 //  © 2023 LY Corporation. All rights reserved.
 //
 
-/// 認可リクエストが成功した結果。
-public struct LoginResult {
+public protocol LoginResult {}
+
+/// 認可リクエストが成功した結果。(Authorization Codeフロー)
+public struct AuthorizationCodeFlowLoginResult: LoginResult {
     // MARK: Public property
     /// 認可コード。
     public let authorizationCode: String
 
-    internal let state: String?
+    /// リクエスト時に指定されたstate値
+    public let state: String?
+}
+
+/// 認可リクエストが成功した結果。(HybridFlow)
+public struct HyblidFlowLoginResult: LoginResult {
+    /// 認可コード。
+    public let authorizationCode: String
+    
+    /// トークン種別。
+    public let tokenType: String?
+    
+    /// IDトークン。
+    public let idToken: String?
+    
+    /// アクセストークン。
+    public let accessToken: String?
+    
+    /// リクエスト時に指定されたstate値
+    public let state: String?
+}
+
+/// 認可リクエストが成功した結果。(ImplicitFlow)
+public struct ImplicitFlowLoginResult: LoginResult {
+    /// トークン種別。
+    public let tokenType: String?
+    
+    /// IDトークン。
+    public let idToken: String?
+    
+    /// アクセストークン。
+    public let accessToken: String?
+    
+    /// アクセストークンの有効期限。
+    public let expiresIn: Int?
+    
+    /// リクエスト時に指定されたstate値
+    public let state: String?
 }

--- a/YJLoginSDK/LoginResult.swift
+++ b/YJLoginSDK/LoginResult.swift
@@ -5,11 +5,16 @@
 //  © 2023 LY Corporation. All rights reserved.
 //
 
-public protocol LoginResult {}
+/// 認可リクエストが成功した結果。
+public protocol LoginResult {
+    /// 認証フロー。
+    var flow: Flow { get }
+}
 
 /// 認可リクエストが成功した結果。(Authorization Codeフロー)
 public struct AuthorizationCodeFlowLoginResult: LoginResult {
-    // MARK: Public property
+    public var flow: Flow { return .authenticationCode }
+
     /// 認可コード。
     public let authorizationCode: String
 
@@ -19,6 +24,8 @@ public struct AuthorizationCodeFlowLoginResult: LoginResult {
 
 /// 認可リクエストが成功した結果。(HybridFlow)
 public struct HyblidFlowLoginResult: LoginResult {
+    public var flow: Flow { return .hybrid }
+
     /// 認可コード。
     public let authorizationCode: String
     
@@ -37,6 +44,8 @@ public struct HyblidFlowLoginResult: LoginResult {
 
 /// 認可リクエストが成功した結果。(ImplicitFlow)
 public struct ImplicitFlowLoginResult: LoginResult {
+    public var flow: Flow { return .implicit }
+
     /// トークン種別。
     public let tokenType: String?
     

--- a/YJLoginSDK/Request/AuthenticationRequest.swift
+++ b/YJLoginSDK/Request/AuthenticationRequest.swift
@@ -11,10 +11,10 @@ internal struct AuthenticationRequest {
 
     var path: String = Constant.authorizationPath
     let clientId: String
-    let codeChallenge: String
+    let codeChallenge: String?
     let nonce: String
     let redirectUri: URL
-    let responseType: ResponseType
+    let responseTypes: [ResponseType]
     let scopes: [Scope]
     let state: String?
     var optionalParameter: OptionalParameters?
@@ -25,11 +25,14 @@ internal struct AuthenticationRequest {
             "client_id": clientId,
             "nonce": nonce,
             "redirect_uri": redirectUri.absoluteString,
-            "response_type": responseType.rawValue,
+            "response_type": responseTypes.map { $0.rawValue }.joined(separator: " "),
             "scope": scopes.map {$0.rawValue}.joined(separator: " "),
-            "code_challenge": codeChallenge,
-            "code_challenge_method": "S256",
         ]
+        
+        if let codeChallenge {
+            parameters["code_challenge"] = codeChallenge
+            parameters["code_challenge_method"] = "S256"
+        }
 
         if let state {
             parameters["state"] = state

--- a/YJLoginSDK/Request/ResponseType.swift
+++ b/YJLoginSDK/Request/ResponseType.swift
@@ -9,6 +9,12 @@ import Foundation
 
 /// Yahoo! ID連携の認可レスポンスとして取得するパラメーターを指定するために、認可リクエストに設定する値。
 public enum ResponseType: String {
-    /// Authorization Codeのみを取得。
+    /// Authorization Codeを取得。
     case code
+    
+    /// Access Tokenを取得。
+    case token
+    
+    /// ID Tokenを取得。
+    case idToken = "id_token"
 }

--- a/YJLoginSDK/Response/AuthenticationResponse.swift
+++ b/YJLoginSDK/Response/AuthenticationResponse.swift
@@ -7,29 +7,73 @@
 
 import Foundation
 
-internal struct AuthenticationResponse {
-    let authorizationCode: String
-    let state: String?
-
-    internal init(url: URL, validatingWith expectedState: String? = nil) throws {
+fileprivate func parseQueries(url: URL, flow: Flow) throws -> [String: String?] {
+    var queries: [String:String?] = [:]
+    switch flow {
+    case .authenticationCode:
         guard let urlComponent = URLComponents(formUrlencodedString: url.absoluteString) else {
             throw AuthenticationResponseError.unexpectedError
         }
+        guard let queryItems = urlComponent.queryItems, !queryItems.isEmpty else {
+            throw AuthenticationResponseError.userCancel
+        }
+        for item in queryItems {
+            queries[item.name] = item.value
+        }
+    default:
+        guard let queryString = url.fragment else {
+            throw AuthenticationResponseError.unexpectedError
+        }
+        let queryPairs = queryString.split(separator: "&").map { String($0) }
+        for pairString in queryPairs {
+            let pair = pairString.split(separator: "=").map { String($0) }
+            queries[pair[0]] = pair[1]
+        }
+    }
+    return queries
+}
 
-        var tmpCode: String?
+internal struct AuthenticationResponse {
+    let responseTypes: [ResponseType]
+    let flow: Flow
+    
+    let authorizationCode: String?
+    let tokenType: String?
+    let idToken: String?
+    let accessToken: String?
+    let expiresIn: Int?
+    let state: String?
+
+    internal init(url: URL, validatingWith expectedState: String? = nil, responseTypes: [ResponseType]) throws {
+        self.responseTypes = responseTypes
+        self.flow = Flow(responseTypes: responseTypes)
+        
+        var authorizationCode: String?
+        var tokenType: String?
+        var idToken: String?
+        var accessToken: String?
+        var expiresIn: Int?
         var state: String?
         var error: String?
         var errorDescription: String?
         var errorCode: Int?
 
-        guard let queryItems = urlComponent.queryItems, !queryItems.isEmpty else {
-            throw AuthenticationResponseError.userCancel
-        }
+        let queries = try! parseQueries(url: url, flow: flow)
 
-        for item in queryItems {
-            switch item.name {
+        for item in queries {
+            switch item.key {
             case "code":
-                tmpCode = item.value
+                authorizationCode = item.value
+            case "token_type":
+                tokenType = item.value
+            case "id_token":
+                idToken = item.value
+            case "access_token":
+                accessToken = item.value
+            case "expires_in":
+                if let value = item.value, let intValue = Int(value) {
+                    expiresIn = intValue
+                }
             case "state":
                 state = item.value
             case "error":
@@ -66,11 +110,49 @@ internal struct AuthenticationResponse {
             throw AuthenticationResponseError.serverError(error: responseError, description: errorDescription, code: errorCode)
         }
 
-        guard let unwrappedTmpCode = tmpCode else {
-            throw AuthenticationResponseError.emptyAuthorizationCode
-        }
-
-        authorizationCode = unwrappedTmpCode
+        self.authorizationCode = authorizationCode
+        self.tokenType = tokenType
+        self.idToken = idToken
+        self.accessToken = accessToken
+        self.expiresIn = expiresIn
         self.state = state
+    }
+    
+    func loginResult() throws -> LoginResult {
+        switch flow {
+        case .authenticationCode:
+            guard let authorizationCode else {
+                throw AuthenticationResponseError.emptyAuthorizationCode
+            }
+            return AuthorizationCodeFlowLoginResult(authorizationCode: authorizationCode, state: state)
+        case .hybrid:
+            guard let authorizationCode else {
+                throw AuthenticationResponseError.emptyAuthorizationCode
+            }
+            if responseTypes.firstIndex(of: .token) != nil {
+                guard accessToken != nil && tokenType != nil else {
+                    throw AuthenticationResponseError.emptyAccessToken
+                }
+            }
+            if responseTypes.firstIndex(of: .idToken) != nil {
+                guard idToken != nil else {
+                    throw AuthenticationResponseError.emptyIdToken
+                }
+            }
+            return HyblidFlowLoginResult(authorizationCode: authorizationCode, tokenType: tokenType, idToken: idToken, accessToken: accessToken, state: state)
+        case .implicit:
+            if responseTypes.firstIndex(of: .token) != nil {
+                guard accessToken != nil && tokenType != nil && expiresIn != nil else {
+                    throw AuthenticationResponseError.emptyAccessToken
+                }
+            }
+            if responseTypes.firstIndex(of: .idToken) != nil {
+                guard idToken != nil else {
+                    throw AuthenticationResponseError.emptyIdToken
+                }
+            }
+            return ImplicitFlowLoginResult(tokenType: tokenType, idToken: idToken, accessToken: accessToken, expiresIn: expiresIn, state: state)
+
+        }
     }
 }

--- a/YJLoginSDK/Response/AuthenticationResponse.swift
+++ b/YJLoginSDK/Response/AuthenticationResponse.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-fileprivate func parseQueries(url: URL, flow: Flow) throws -> [String: String?] {
-    var queries: [String:String?] = [:]
+private func parseQueries(url: URL, flow: Flow) throws -> [String: String?] {
+    var queries: [String: String?] = [:]
     switch flow {
     case .authenticationCode:
         guard let urlComponent = URLComponents(formUrlencodedString: url.absoluteString) else {

--- a/YJLoginSDK/Response/AuthenticationResponse.swift
+++ b/YJLoginSDK/Response/AuthenticationResponse.swift
@@ -139,7 +139,7 @@ internal struct AuthenticationResponse {
                     throw AuthenticationResponseError.emptyIdToken
                 }
             }
-            return HyblidFlowLoginResult(authorizationCode: authorizationCode, tokenType: tokenType, idToken: idToken, accessToken: accessToken, state: state)
+            return HybridFlowLoginResult(authorizationCode: authorizationCode, tokenType: tokenType, idToken: idToken, accessToken: accessToken, state: state)
         case .implicit:
             if responseTypes.firstIndex(of: .token) != nil {
                 guard accessToken != nil && tokenType != nil && expiresIn != nil else {

--- a/YJLoginSDK/Response/AuthenticationResponse.swift
+++ b/YJLoginSDK/Response/AuthenticationResponse.swift
@@ -57,8 +57,8 @@ internal struct AuthenticationResponse {
         var error: String?
         var errorDescription: String?
         var errorCode: Int?
-
-        let queries = try! parseQueries(url: url, flow: flow)
+        
+        let queries = try parseQueries(url: url, flow: flow)
 
         for item in queries {
             switch item.key {

--- a/YJLoginSDK/Response/AuthenticationResponseError.swift
+++ b/YJLoginSDK/Response/AuthenticationResponseError.swift
@@ -11,6 +11,8 @@ internal enum AuthenticationResponseError: Error {
     case userCancel
     case invalidState
     case emptyAuthorizationCode
+    case emptyIdToken
+    case emptyAccessToken
     case unexpectedError
     case undefinedError(error: String, description: String, code: Int)
     case serverError(error: Error, description: String, code: Int)

--- a/YJLoginSDKTests/AuthenticationProcessTests.swift
+++ b/YJLoginSDKTests/AuthenticationProcessTests.swift
@@ -17,7 +17,7 @@ class AuthenticationProcessTests: XCTestCase {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&code=code")!))
 
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -40,7 +40,7 @@ class AuthenticationProcessTests: XCTestCase {
 
         let stub = StubUserAgent(result: .failure(error))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -58,7 +58,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_user_cancel_button() {
         let stub = StubUserAgent(result: .success(URL(string: "scheme:/?")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -76,7 +76,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_system_error() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=server_error&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -97,7 +97,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_response_failed_invalid_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=invalid_state&code=code")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -115,7 +115,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_response_failed_missing_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?code=code")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -133,7 +133,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_response_failed_unnecessary_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?code=code&state=state")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: nil)
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: nil)
 
         let expect = self.expectation(description: self.name)
 
@@ -151,7 +151,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_response_failed_undefined() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=unexpected_error&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -172,7 +172,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_response_failed_missing_authorization_code() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -190,7 +190,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_user_interaction_required_login_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=login_required&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -211,7 +211,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_user_interaction_required_consent_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=consent_required&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -232,7 +232,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_user_interaction_required_interaction_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=interaction_required&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -253,7 +253,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_request_failed_access_denied() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=access_denied&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -274,7 +274,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_request_failed_invalid_scope() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=invalid_scope&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -295,7 +295,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_request_failed_invalid_request() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=invalid_request&error_description=hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -316,7 +316,7 @@ class AuthenticationProcessTests: XCTestCase {
     func test_request_failed_unsupported_response_type() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=unsupported_response_type&error_description=hogehoge+hogehoge&error_code=1000")!))
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -339,7 +339,7 @@ class AuthenticationProcessTests: XCTestCase {
         let stub = StubUserAgent(result: .failure(expectedError))
 
         process = AuthenticationProcess(ua: stub)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
@@ -361,7 +361,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_resume_success() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertTrue(process!.resume(url: URL(string: "scheme:/?")!))
     }
@@ -373,42 +373,42 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_resume_invalid_redirect_uri_scheme() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "invalidscheme:/")!))
     }
 
     func test_resume_invalid_redirect_path() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme://path?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme://path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "scheme://invalidpath")!))
     }
 
     func test_resume_invalid_redirect_user() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://invaliduser:passwd@host/path")!))
     }
 
     func test_resume_invalid_redirect_password() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://user:invalidpasswd@host/path")!))
     }
 
     func test_resume_invalid_redirect_port() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://host/path:0000")!))
     }
 
     func test_resume_invalid_redirect_host() {
         process = AuthenticationProcess(viewController: nil)
-        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseType: .code, scopes: [.openid, .profile], state: "state")
+        let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://invalidhost/path:8080")!))
     }

--- a/YJLoginSDKTests/AuthenticationProcessTests.swift
+++ b/YJLoginSDKTests/AuthenticationProcessTests.swift
@@ -16,13 +16,17 @@ class AuthenticationProcessTests: XCTestCase {
     func test_normal() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&code=code")!))
 
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
 
         process?.onFinish = { result in
             if case .success(let result) = result {
+                guard let result = result as? AuthorizationCodeFlowLoginResult else {
+                    XCTFail("Test failed.")
+                    return
+                }
                 XCTAssertEqual(result.authorizationCode, "code")
                 XCTAssertEqual(result.state, "state")
                 expect.fulfill()
@@ -39,7 +43,7 @@ class AuthenticationProcessTests: XCTestCase {
         error = ASWebAuthenticationSessionError.init(.canceledLogin)
 
         let stub = StubUserAgent(result: .failure(error))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -57,7 +61,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_user_cancel_button() {
         let stub = StubUserAgent(result: .success(URL(string: "scheme:/?")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -75,7 +79,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_system_error() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=server_error&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -96,7 +100,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_response_failed_invalid_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=invalid_state&code=code")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -114,7 +118,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_response_failed_missing_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?code=code")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -132,7 +136,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_response_failed_unnecessary_state() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?code=code&state=state")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: nil)
 
         let expect = self.expectation(description: self.name)
@@ -150,7 +154,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_response_failed_undefined() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=unexpected_error&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -171,7 +175,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_response_failed_missing_authorization_code() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -189,7 +193,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_user_interaction_required_login_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=login_required&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -210,7 +214,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_user_interaction_required_consent_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=consent_required&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -231,7 +235,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_user_interaction_required_interaction_required() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=interaction_required&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -252,7 +256,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_request_failed_access_denied() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=access_denied&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -273,7 +277,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_request_failed_invalid_scope() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=invalid_scope&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -294,7 +298,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_request_failed_invalid_request() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=invalid_request&error_description=hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -315,7 +319,7 @@ class AuthenticationProcessTests: XCTestCase {
 
     func test_request_failed_unsupported_response_type() {
         let stub = StubUserAgent(result: .success(URL(string: "test:/?state=state&error=unsupported_response_type&error_description=hogehoge+hogehoge&error_code=1000")!))
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -338,7 +342,7 @@ class AuthenticationProcessTests: XCTestCase {
         let expectedError = NSError(domain: "test", code: 0, userInfo: nil)
         let stub = StubUserAgent(result: .failure(expectedError))
 
-        process = AuthenticationProcess(ua: stub)
+        process = AuthenticationProcess(ua: stub, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
 
         let expect = self.expectation(description: self.name)
@@ -360,54 +364,54 @@ class AuthenticationProcessTests: XCTestCase {
     }
 
     func test_resume_success() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertTrue(process!.resume(url: URL(string: "scheme:/?")!))
     }
 
     func test_resume_request_null() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         XCTAssertFalse(process!.resume(url: URL(string: "scheme:/")!))
     }
 
     func test_resume_invalid_redirect_uri_scheme() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme:/?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "invalidscheme:/")!))
     }
 
     func test_resume_invalid_redirect_path() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "scheme://path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "scheme://invalidpath")!))
     }
 
     func test_resume_invalid_redirect_user() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://invaliduser:passwd@host/path")!))
     }
 
     func test_resume_invalid_redirect_password() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://user:passwd@host/path?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://user:invalidpasswd@host/path")!))
     }
 
     func test_resume_invalid_redirect_port() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://host/path:0000")!))
     }
 
     func test_resume_invalid_redirect_host() {
-        process = AuthenticationProcess(viewController: nil)
+        process = AuthenticationProcess(viewController: nil, responseTypes: [.code])
         let request = AuthenticationRequest(clientId: "client_id", codeChallenge: "code_challenge", nonce: "nonce", redirectUri: URL(string: "https://host/path:8080?")!, responseTypes: [.code], scopes: [.openid, .profile], state: "state")
         process?.start(request: request)
         XCTAssertFalse(process!.resume(url: URL(string: "https://invalidhost/path:8080")!))

--- a/YJLoginSDKTests/AuthenticationRequestTests.swift
+++ b/YJLoginSDKTests/AuthenticationRequestTests.swift
@@ -14,7 +14,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce+nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state"
         )
@@ -53,7 +53,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state",
             optionalParameter: optionalParameters
@@ -97,7 +97,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state",
             optionalParameter: optionalParameters
@@ -158,7 +158,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state",
             optionalParameter: optionalParameters
@@ -190,7 +190,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state",
             optionalParameter: optionalParameters
@@ -234,7 +234,7 @@ class AuthenticationRequstTests: XCTestCase {
             codeChallenge: "code_challenge",
             nonce: "nonce",
             redirectUri: URL(string: "scheme:/")!,
-            responseType: .code,
+            responseTypes: [.code],
             scopes: [.address, .email, .openid, .profile],
             state: "state",
             optionalParameter: optionalParameters,

--- a/YJLoginSDKTests/LoginButtonTests.swift
+++ b/YJLoginSDKTests/LoginButtonTests.swift
@@ -15,7 +15,7 @@ class LoginButtonTests: XCTestCase {
 
     func test_login_success() {
         let vc = ViewController()
-        vc.process = StubProcess(result: .success(LoginResult(authorizationCode: "code", state: "state")))
+        vc.process = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "code", state: "state")))
         vc.viewDidLoad()
         vc.button.sendActions(for: .touchUpInside)
         XCTAssertEqual(vc.startCount, 1)

--- a/YJLoginSDKTests/LoginManagerTests.swift
+++ b/YJLoginSDKTests/LoginManagerTests.swift
@@ -14,11 +14,14 @@ class LoginManagetTests: XCTestCase {
     }
 
     func test_login_success() {
-        let stubProcess = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: nil)))
+        let stubProcess = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: nil)))
         let expect = self.expectation(description: self.name)
 
         LoginManager.shared.login(scopes: [.openid], nonce: "nonce", codeChallenge: "code_challenge", process: stubProcess) { result in
-            let result = try! result.get()
+            guard let result = try? result.get() as? AuthorizationCodeFlowLoginResult else {
+                XCTFail("The result should be an instance of AuthorizationCodeFlowLoginResult class.")
+                return
+            }
             XCTAssertEqual(result.authorizationCode, "abc")
             expect.fulfill()
         }
@@ -27,11 +30,14 @@ class LoginManagetTests: XCTestCase {
     }
 
     func test_login_optional_parameter_success() {
-        let stubProcess = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: "state")))
+        let stubProcess = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: "state")))
         let expect = self.expectation(description: self.name)
         let optionalParameters = OptionalParameters(bail: true)
         LoginManager.shared.login(scopes: [.openid], nonce: "nonce", codeChallenge: "code_challenge", process: stubProcess, optionalParameters: optionalParameters) { result in
-            let result = try! result.get()
+            guard let result = try? result.get() as? AuthorizationCodeFlowLoginResult else {
+                XCTFail("The result should be an instance of AuthorizationCodeFlowLoginResult class.")
+                return
+            }
             XCTAssertEqual(result.authorizationCode, "abc")
             XCTAssertEqual(result.state, "state")
             expect.fulfill()
@@ -56,14 +62,17 @@ class LoginManagetTests: XCTestCase {
 
     func test_login_concurrent_with_disable_universal_links() {
         LoginManager.shared.setEnableUniversalLinks(enableUniversalLinks: false)
-        let stubProcess = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: nil)))
+        let stubProcess = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: nil)))
         let expect = self.expectation(description: self.name)
-        let stubProcess2 = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: nil)))
+        let stubProcess2 = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: nil)))
         let expect2 = self.expectation(description: self.name)
 
         DispatchQueue.global().async {
             LoginManager.shared.login(scopes: [.openid], nonce: "nonce", codeChallenge: "code_challenge", process: stubProcess) { result in
-                let result = try! result.get()
+                guard let result = try? result.get() as? AuthorizationCodeFlowLoginResult else {
+                    XCTFail("The result should be an instance of AuthorizationCodeFlowLoginResult class.")
+                    return
+                }
                 XCTAssertEqual(result.authorizationCode, "abc")
                 expect.fulfill()
             }
@@ -86,14 +95,17 @@ class LoginManagetTests: XCTestCase {
 
     func test_login_concurrent_with_enable_universal_links() {
         LoginManager.shared.setEnableUniversalLinks(enableUniversalLinks: true)
-        let stubProcess = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: nil)))
+        let stubProcess = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: nil)))
         let expect = self.expectation(description: self.name)
-        let stubProcess2 = StubProcess(result: .success(LoginResult(authorizationCode: "abc", state: nil)))
+        let stubProcess2 = StubProcess(result: .success(AuthorizationCodeFlowLoginResult(authorizationCode: "abc", state: nil)))
         let expect2 = self.expectation(description: self.name)
 
         DispatchQueue.global().async {
             LoginManager.shared.login(scopes: [.openid], nonce: "nonce", codeChallenge: "code_challenge", process: stubProcess) { result in
-                let result = try! result.get()
+                guard let result = try? result.get() as? AuthorizationCodeFlowLoginResult else {
+                    XCTFail("The result should be an instance of AuthorizationCodeFlowLoginResult class.")
+                    return
+                }
                 XCTAssertEqual(result.authorizationCode, "abc")
                 expect.fulfill()
             }
@@ -103,7 +115,10 @@ class LoginManagetTests: XCTestCase {
 
         DispatchQueue.global().async {
             LoginManager.shared.login(scopes: [.openid], nonce: "nonce", codeChallenge: "code_challenge", process: stubProcess2) { result in
-                let result = try! result.get()
+                guard let result = try? result.get() as? AuthorizationCodeFlowLoginResult else {
+                    XCTFail("The result should be an instance of AuthorizationCodeFlowLoginResult class.")
+                    return
+                }
                 XCTAssertEqual(result.authorizationCode, "abc")
                 expect2.fulfill()
             }


### PR DESCRIPTION
# 主な対応内容
現行のSwift版yjlogin-ios-sdkではサポートしていない以下の認証フローを使えるようにするための改造を実施する。
- [Implicit Flow](https://developer.yahoo.co.jp/yconnect/v2/implicit/)
- [Hybrid Flow](https://developer.yahoo.co.jp/yconnect/v2/hybrid/)

認証フローはresponseTypesによって変わる。

ログイン時、stateを代入できるようにする(LoginManagerのみ)

`LoginResult` はプロトコルとなり、各フローごとにこのプロトコルのサブクラスとして実装する

